### PR TITLE
fix: build module when it is in a vendor directory or the module cache

### DIFF
--- a/internal/modload/init.go
+++ b/internal/modload/init.go
@@ -33,12 +33,33 @@ func HasModRoot() bool {
 		modPath := filepath.Join(cwd, "go.mod")
 		if _, err := os.Stat(modPath); err == nil {
 			modRoot = cwd
+			if vendorRoot, ok := findVendorMod(modRoot); ok {
+				modRoot = vendorRoot
+			}
 			return true
 		} else if cwd == "/" {
 			return false
 		}
 		cwd = filepath.Dir(cwd)
 	}
+}
+
+// findVendorMod will find the module file for the
+// project vendoring this dependency if we are inside
+// of a vendor directory.
+func findVendorMod(cwd string) (string, bool) {
+	cwd = filepath.Dir(cwd)
+	for cwd != "/" {
+		modPath := filepath.Join(cwd, "go.mod")
+		if _, err := os.Stat(modPath); err == nil {
+			vendorPath := filepath.Join(cwd, "vendor")
+			if st, err := os.Stat(vendorPath); err == nil && st.IsDir() {
+				return cwd, true
+			}
+		}
+		cwd = filepath.Dir(cwd)
+	}
+	return "", false
 }
 
 func die(msg string) {


### PR DESCRIPTION
The `pkg-config` executable made the erroneous assumption it would be
called within the directory of the project that was invoking it rather
than inside of the package that was using it.

The `pkg-config` executable can now recognize when it is called from
within the module cache and it can find the version by using the
directory filepath instead of relying on git for those situations.

It also is now able to recognize when it is within a vendor directory.
After it finds the module root, it looks to see if there is another
module root in the path with a vendor directory. If there is, it will
use the original project instead of the vendored directory and it will
proceed with the `go mod download` workflow.