### PR TITLE
fix: do not search the path for the executable if it was specified with PKG_CONFIG

### DIFF
--- a/libs/flux/build.go
+++ b/libs/flux/build.go
@@ -76,7 +76,11 @@ func (l *Library) Install(ctx context.Context, logger *zap.Logger) error {
 	}
 
 	var stderr bytes.Buffer
-	cmd := exec.Command("cargo", "build", "--release")
+	cargoCmd := os.Getenv("CARGO")
+	if cargoCmd == "" {
+		cargoCmd = "cargo"
+	}
+	cmd := exec.Command(cargoCmd, "build", "--release")
 	cmd.Stdout = &stderr
 	cmd.Stderr = &stderr
 	cmd.Dir = filepath.Join(l.Dir, "libflux")


### PR DESCRIPTION
If the application was specified with `pkg-config`, it would still look
on the path for itself and would remove the real `pkg-config`. This
fixes it so it recognizes that `PKG_CONFIG` was set and will unset that
environment variable instead of modifying the path. If it was wrong and
`PKG_CONFIG` was not used to invoke it, this just causes it to call
itself once rather than infinitely.

This also modifies `pkg-config` to use the `CARGO` environment variable
to find `cargo` for the flux build. This makes it easier to configure
for an IDE that doesn't have cargo on the normal path.