### PR TITLE
fix: do not print the environment when overwriting the environment

### DIFF
--- a/libs/flux/build.go
+++ b/libs/flux/build.go
@@ -216,7 +216,6 @@ func (l *Library) build(ctx context.Context, logger *zap.Logger) (string, error)
 		cmd.Env = removeEnvVar(cmd.Env, "CC")
 		cmd.Env = removeEnvVar(cmd.Env, "CXX")
 		cmd.Env = removeEnvVar(cmd.Env, "AR")
-		logger.Info("Overwrote rust build environment", zap.Strings("env", cmd.Env))
 	}
 	logger.Info("Executing cargo build", zap.String("dir", cmd.Dir), zap.String("target", targetString))
 	if err := cmd.Run(); err != nil {


### PR DESCRIPTION
When we print the environment when overwriting the environment, we risk
printing any sensitive information that was held inside of environment
variables. Now that we have determined that this code works, the log
message should be removed to avoid leaking credentials.