### PR TITLE
fix: modifyPath does a full filter

### DIFF
--- a/main.go
+++ b/main.go
@@ -70,6 +70,7 @@ func modifyPath(arg0path string) error {
 	// are in the list after our current one.
 	// We work backwards so we can find the last entry for the executable in case
 	// the same path is on the path twice.
+	var filteredList []string
 	for i := len(list) - 1; i >= 0; i-- {
 		dir := list[i]
 		if dir == "" {
@@ -79,13 +80,12 @@ func modifyPath(arg0path string) error {
 
 		dir, _ = filepath.Abs(dir)
 		path := filepath.Join(dir, pkgConfigExecName)
-		if arg0path == path {
+		if arg0path != path {
 			// Modify the list to exclude the current element and break out of the loop.
-			list = list[i+1:]
-			break
+			filteredList = append(filteredList, dir)
 		}
 	}
-	path = strings.Join(list, string(filepath.ListSeparator))
+	path = strings.Join(filteredList, string(filepath.ListSeparator))
 	return os.Setenv("PATH", path)
 }
 

--- a/main.go
+++ b/main.go
@@ -70,9 +70,7 @@ func modifyPath(arg0path string) error {
 	// are in the list after our current one.
 	// We work backwards so we can find the last entry for the executable in case
 	// the same path is on the path twice.
-	var filteredList []string
-	for i := len(list) - 1; i >= 0; i-- {
-		dir := list[i]
+	for i, dir := range list {
 		if dir == "" {
 			// Unix shell semantics: path element "" means "."
 			dir = "."
@@ -80,12 +78,13 @@ func modifyPath(arg0path string) error {
 
 		dir, _ = filepath.Abs(dir)
 		path := filepath.Join(dir, pkgConfigExecName)
-		if arg0path != path {
+		if arg0path == path {
 			// Modify the list to exclude the current element and break out of the loop.
-			filteredList = append(filteredList, dir)
+			copy(list[i:], list[i+1:])
+			list = list[:len(list)-1]
 		}
 	}
-	path = strings.Join(filteredList, string(filepath.ListSeparator))
+	path = strings.Join(list, string(filepath.ListSeparator))
 	return os.Setenv("PATH", path)
 }
 


### PR DESCRIPTION
Problem description:
When I tried to debug a test in idpe, I got the following error message (in Goland):
```
GOROOT=/usr/local/go #gosetup
GOPATH=/Users/ezhang/go #gosetup
/usr/local/go/bin/go test -c -o /private/var/folders/wj/1552tb29139c1tqf7vjkclgc0000gq/T/___TestPipeline_WriteV1_Query_in_github_com_influxdata_idpe_tests -gcflags "all=-N -l" github.com/influxdata/idpe/tests #gosetup
# pkg-config --cflags  -- flux
Started pkg-config	{"arg0": "/Users/ezhang/go/bin/pkg-config", "args": ["--cflags", "--", "flux"]}
Could not find pkg-config executable	{"path": "/usr/local/go/bin", "error": "exec: \"pkg-config\": executable file not found in $PATH"}
pkg-config: exit status 1
```

Goland will add `/Users/ezhang/go/bin:/usr/local/go/bin` to the end of `PATH`. Our `pkg-config` scans `PATH` from the end to the beginning to exclude the current element so in Goland the `PATH` ended up being just `/usr/local/go/bin`. This causes the problem not being able to correctly locate the `pkg-config`.