### PR TITLE
fix: set CC when building for macOS

### DIFF
--- a/libs/flux/build.go
+++ b/libs/flux/build.go
@@ -211,11 +211,19 @@ func (l *Library) build(ctx context.Context, logger *zap.Logger) (string, error)
 	if targetString != "" {
 		cmd.Args = append(cmd.Args, "--target", targetString)
 
-		// Remove CC, CXX, and AR from the environment if the target is not ourselves.
-		// These variables interfere with the rust compiler toolchain's build.rs files.
-		cmd.Env = removeEnvVar(cmd.Env, "CC")
-		cmd.Env = removeEnvVar(cmd.Env, "CXX")
-		cmd.Env = removeEnvVar(cmd.Env, "AR")
+		// If the target environment is not also the host environment, CC set to "xcc" will
+		// be incorrect, and will interfere with build time compilation. For linux, unsetting the
+		// value is fine, as rust will correctly assume gcc. For macOS, however, we must explicitly
+		// set CC to clang.
+		if l.Target.OS == "darwin" {
+			cmd.Env = setEnvVar(cmd.Env, "CC", "clang")
+		} else if l.Target.OS == "linux" {
+			// Remove CC, CXX, and AR from the environment if the target is not ourselves.
+			// These variables interfere with the rust compiler toolchain's build.rs files.
+			cmd.Env = removeEnvVar(cmd.Env, "CC")
+			cmd.Env = removeEnvVar(cmd.Env, "CXX")
+			cmd.Env = removeEnvVar(cmd.Env, "AR")
+		}
 	}
 	logger.Info("Executing cargo build", zap.String("dir", cmd.Dir), zap.String("target", targetString))
 	if err := cmd.Run(); err != nil {
@@ -447,6 +455,23 @@ func removeEnvVar(env []string, key string) []string {
 			env = env[:len(env)-1]
 			break
 		}
+	}
+	return env
+}
+
+func setEnvVar(env []string, key string, value string) []string {
+	found := false
+	prefix := key + "="
+	envString := prefix + value
+	for i, kv := range env {
+		if strings.HasPrefix(kv, prefix) {
+			found = true
+			env[i] = envString
+			break
+		}
+	}
+	if !found {
+		env = append(env, envString)
 	}
 	return env
 }


### PR DESCRIPTION
Currently, the pkg-config unsets the `CC` environment variable when
cross-compiling. This causes problems when darwin then tries to use the
default compiler, `gcc`, where the final linking would use `clang` and thus be incompatible.