### PR TITLE
fix: hash the libraries to produce a unique file per source input

### DIFF
--- a/main.go
+++ b/main.go
@@ -24,11 +24,11 @@ const pkgConfigExecName = "pkg-config"
 type Library interface {
 	// Install will be used to build and install the library into
 	// the directory.
-	Install(ctx context.Context, l *zap.Logger) error
+	Install(ctx context.Context, l *zap.Logger) (string, error)
 
 	// WritePackageConfig will write out the package configuration
 	// for this library to the given writer.
-	WritePackageConfig(w io.Writer) error
+	WritePackageConfig(w io.Writer, buildid string) error
 }
 
 // getArg0Path gets an absolute path to where this binary was executed.
@@ -220,7 +220,8 @@ func realMain() int {
 			logger.Error("Error configuring library", zap.String("name", lib), zap.Error(err))
 			return 1
 		} else if ok {
-			if err := l.Install(ctx, logger); err != nil {
+			buildid, err := l.Install(ctx, logger)
+			if err != nil {
 				logger.Error("Error installing library", zap.String("name", lib), zap.Error(err))
 				return 1
 			}
@@ -232,7 +233,7 @@ func realMain() int {
 				return 1
 			}
 
-			if err := l.WritePackageConfig(f); err != nil {
+			if err := l.WritePackageConfig(f, buildid); err != nil {
 				logger.Error("Error writing pkg-config configuration file", zap.String("path", pkgfile), zap.Error(err))
 				return 1
 			}


### PR DESCRIPTION
This changes `pkg-config` to produce a unique hashed linked output and
configures it to output a link command that includes that hash. This is
done because Go will hash the output of `pkg-config` and it will hash
multiple builds.

For example, it is possible to use `pkg-config` on one build and get a
valid output. Then you make a modification and use it again and get
another valid output. If you revert back to the first build input,
go will believe the library has already been built and won't run
`pkg-config` again. It will link against the output from the second
build.

This is because go's invocation of `pkg-config` always assumes that
nothing changes. By adding these hashes, go will use the first
`pkg-config` invocation's output and link against the correct library.

This mostly affects local builds because local builds are the only
circumstance where `pkg-config` will overwrite the old file. Module and
vendor builds aren't affected because they produce a unique directory
output.