### PR TITLE
fix: add static-build cases for libflux on ARM

### DIFF
--- a/libs/flux/build.go
+++ b/libs/flux/build.go
@@ -52,10 +52,16 @@ func (t Target) DetermineCargoTarget(logger *zap.Logger) string {
 		return "i686-unknown-linux-gnu"
 	case t.OS == "linux" && t.Arch == "arm" && t.Arm == "6" && !t.Static:
 		return "arm-unknown-linux-gnueabihf"
+	case t.OS == "linux" && t.Arch == "arm" && t.Arm == "6" && t.Static:
+		return "arm-unknown-linux-musleabihf"
 	case t.OS == "linux" && t.Arch == "arm" && t.Arm == "7" && !t.Static:
 		return "armv7-unknown-linux-gnueabihf"
+	case t.OS == "linux" && t.Arch == "arm" && t.Arm == "7" && t.Static:
+		return "armv7-unknown-linux-musleabihf"
 	case t.OS == "linux" && t.Arch == "arm64" && !t.Static:
 		return "aarch64-unknown-linux-gnu"
+	case t.OS == "linux" && t.Arch == "arm64" && t.Static:
+		return "aarch64-unknown-linux-musl"
 	case t.OS == "darwin" && t.Arch == "amd64":
 		return "x86_64-apple-darwin"
 	case t.OS == "windows" && t.Arch == "amd64":


### PR DESCRIPTION
Resolves #26 

I wasn't sure of the best way to test these changes, but I took a first stab by using the [cross](https://github.com/rust-embedded/cross) tool to check that `cargo build --release` and `cargo test` both succeed for the flux repo when using each of the 3 new architectures.