### PR TITLE
fix: add -lm command to flux build process

### DIFF
--- a/libs/flux/build.go
+++ b/libs/flux/build.go
@@ -242,6 +242,11 @@ func (l *Library) build(ctx context.Context, logger *zap.Logger) (string, error)
 	if targetString != "" {
 		cmd.Args = append(cmd.Args, "--target", targetString)
 	}
+
+	if l.Target.OS == "linux" {
+		cmd.Args = append(cmd.Args, "-lm")
+	}
+
 	logger.Info("Executing cargo build", zap.String("dir", cmd.Dir), zap.String("target", targetString))
 	if err := cmd.Run(); err != nil {
 		logutil.LogOutput(&stderr, logger)


### PR DESCRIPTION
This is a fix for flux#4039. It allows support for go math intrinsics. This is required to support recent changes in Go 1.55. 