### PR TITLE
fix: Flux needs to link to bcrypt on windows on Rust 1.58

### DIFF
--- a/libs/flux/build.go
+++ b/libs/flux/build.go
@@ -282,7 +282,7 @@ Name: Flux
 			_, _ = fmt.Fprintf(w, "Libs: -L${libdir} -lflux-${buildid} -ldl -lm\n")
 		}
 	} else if l.Target.OS == "windows" {
-		_, _ = fmt.Fprintf(w, "Libs: -L${libdir} -lflux-${buildid} -lws2_32 -luserenv\n")
+		_, _ = fmt.Fprintf(w, "Libs: -L${libdir} -lflux-${buildid} -lws2_32 -luserenv -lbcrypt\n")
 	} else {
 		_, _ = fmt.Fprintf(w, "Libs: -L${libdir} -lflux-${buildid}\n")
 	}


### PR DESCRIPTION
Due to https://github.com/rust-lang/rust/pull/84096 we need to link to bcrypt on windows else we get linker errors.

cc https://github.com/influxdata/flux/pull/4406

https://app.circleci.com/pipelines/github/influxdata/flux/11766/workflows/d1ef0c61-babb-4682-8c74-7087013c873e/jobs/38341

```
C:\\Users\\circleci\\AppData\\Local\\go-build\\pkgconfig\\windows_amd64\\lib/libflux-3dd4b4346280d5a830d03b58d109be24cf44fd0ab5964e0113b470e7ba1223ed.a(std-c90c2a9f63fc5684.std.04e7289e-cgu.0.rcgu.o): In function `std::sys::windows::rand::hashmap_random_keys':
/rustc/02072b482a8b5357f7fb5e5637444ae30e423c40\/library\std\src\sys\windows/rand.rs:10: undefined reference to `BCryptGenRandom'
/rustc/02072b482a8b5357f7fb5e5637444ae30e423c40\/library\std\src\sys\windows/rand.rs:10: undefined reference to `BCryptGenRandom'
collect2.exe: error: ld returned 1 exit status

Exited with code exit status 2

```