### PR TITLE
refactor: make pkg-config agnostic to org in module path

### DIFF
--- a/constants_unix.go
+++ b/constants_unix.go
@@ -1,4 +1,5 @@
-//+build !windows
+//go:build !windows
+// +build !windows
 
 package main
 

--- a/internal/modfile/read.go
+++ b/internal/modfile/read.go
@@ -244,7 +244,6 @@ func (x *Line) Span() (start, end Position) {
 //		"x"
 //		"y"
 //	)
-//
 type LineBlock struct {
 	Comments
 	Start  Position

--- a/libs/flux/constants_unix.go
+++ b/libs/flux/constants_unix.go
@@ -1,4 +1,5 @@
-//+build !windows
+//go:build !windows
+// +build !windows
 
 package flux
 
@@ -6,7 +7,7 @@ import "regexp"
 
 // fluxVersionRegexp is used to extract the version of flux pulled down by `go mod` by inspecting
 // its path on the filesystem.
-var fluxVersionRegexp = regexp.MustCompile(`/github\.com/influxdata/flux@(v\d+\.\d+\.\d+.*)$`)
+var fluxVersionRegexp = regexp.MustCompile(`/github\.com/[^/]+/flux@(v\d+\.\d+\.\d+.*)$`)
 
 // pcSep is the separator used between components in all the path-fields written into `flux.pc`
 // by our `pkg-config` wrapper. On Unix, the standard path separator works without problems.

--- a/libs/flux/constants_windows.go
+++ b/libs/flux/constants_windows.go
@@ -4,12 +4,13 @@ import "regexp"
 
 // fluxVersionRegexp is used to extract the version of flux pulled down by `go mod` by inspecting
 // its path on the filesystem.
-var fluxVersionRegexp = regexp.MustCompile(`\\github\.com\\influxdata\\flux@(v\d+\.\d+\.\d+.*)$`)
+var fluxVersionRegexp = regexp.MustCompile(`\\github\.com\\[^\\]+\\flux@(v\d+\.\d+\.\d+.*)$`)
 
 // pcSep is the separator used between components in all the path-fields written into `flux.pc`
 // by our `pkg-config` wrapper. On Windows we have to double-escape the OS's path separator because:
-//   1. The 1st escape is "used" when `pkg-config` prints the paths to the caller (some piece of `go build`)
-//   2. The 2nd escape is "used" when `go build` passes the paths to `ld`
+//  1. The 1st escape is "used" when `pkg-config` prints the paths to the caller (some piece of `go build`)
+//  2. The 2nd escape is "used" when `go build` passes the paths to `ld`
+//
 // With only a single-escape of the path separator, `go build` ends up passing args like `-Lmypathtoflux`
 // instead of `-Lmy\path\to\flux`, and linking fails.
 const pcSep = "\\\\"


### PR DESCRIPTION
When building Flux we use a special version of `pkg-config` that builds the Rust bits in a way that is transparent to the Go build system. Thus far there was only one fork of Flux, so the org `influxdata` was hardcoded into Go module path.

These changes make this specialized version of `pkg-config` usable with the `flux` repo in `influxdata`, or with a fork somewhere else, such as `InfluxCommunity`.