### PR TITLE
fix: Rust >=1.70 needs to explicitly link to ntdll and other libs

### DIFF
--- a/libs/flux/build.go
+++ b/libs/flux/build.go
@@ -282,7 +282,7 @@ Name: Flux
 			_, _ = fmt.Fprintf(w, "Libs: -L${libdir} -lflux-${buildid} -ldl -lm\n")
 		}
 	} else if l.Target.OS == "windows" {
-		_, _ = fmt.Fprintf(w, "Libs: -L${libdir} -lflux-${buildid} -lws2_32 -luserenv -lbcrypt\n")
+		_, _ = fmt.Fprintf(w, "Libs: -L${libdir} -lflux-${buildid} -lkernel32 -ladvapi32 -lbcrypt -lkernel32 -lntdll -luserenv -lws2_32 -lkernel32 -lws2_32 -lkernel32 -lntdll -lkernel32\n")
 	} else {
 		_, _ = fmt.Fprintf(w, "Libs: -L${libdir} -lflux-${buildid}\n")
 	}


### PR DESCRIPTION
Windows builds with Rust >= 1.70 need to explicitly link in ntdll and other associated libraries.

See

* [Rust 1.70 And Build Failures On Windows](https://yutani.rbind.io/post/rust-1.70-and-build-failure-on-windows/)
* [https://github.com/rust-lang/rust/issues/115813](https://github.com/rust-lang/rust/issues/115813)


Without this, builds will fail with messages like the following
```
# github.com/influxdata/flux/internal/cmd/influxql-decode
C:\Program Files\Go\pkg\tool\windows_amd64\link.exe: running gcc failed: exit status 1
C:\\Users\\circleci\\AppData\\Local\\go-build\\pkgconfig\\windows_amd64\\lib/libflux-b2b5313bb4ee0b21150a1a32758418bfca79b1628ee6628f6ba0e7e3e5ce1a4f.a(std-04636370035c201d.std.3b98da929d84a378-cgu.0.rcgu.o): In function `std::sys::windows::fs::open_link_no_reparse':
/rustc/d5c2e9c342b358556da91d61ed4133f6f50fc0c3/library\std\src\sys\windows/fs.rs:829: undefined reference to `NtCreateFile'
/rustc/d5c2e9c342b358556da91d61ed4133f6f50fc0c3/library\std\src\sys\windows/fs.rs:858: undefined reference to `RtlNtStatusToDosError'
C:\\Users\\circleci\\AppData\\Local\\go-build\\pkgconfig\\windows_amd64\\lib/libflux-b2b5313bb4ee0b21150a1a32758418bfca79b1628ee6628f6ba0e7e3e5ce1a4f.a(std-04636370035c201d.std.3b98da929d84a378-cgu.0.rcgu.o): In function `std::sys::windows::c::NtReadFile':
/rustc/d5c2e9c342b358556da91d61ed4133f6f50fc0c3/library\std\src\sys\windows/c.rs:283: undefined reference to `NtReadFile'
C:\\Users\\circleci\\AppData\\Local\\go-build\\pkgconfig\\windows_amd64\\lib/libflux-b2b5313bb4ee0b21150a1a32758418bfca79b1628ee6628f6ba0e7e3e5ce1a4f.a(std-04636370035c201d.std.3b98da929d84a378-cgu.0.rcgu.o): In function `std::sys::windows::handle::Handle::synchronous_read':
/rustc/d5c2e9c342b358556da91d61ed4133f6f50fc0c3/library\std\src\sys\windows/handle.rs:273: undefined reference to `RtlNtStatusToDosError'
C:\\Users\\circleci\\AppData\\Local\\go-build\\pkgconfig\\windows_amd64\\lib/libflux-b2b5313bb4ee0b21150a1a32758418bfca79b1628ee6628f6ba0e7e3e5ce1a4f.a(std-04636370035c201d.std.3b98da929d84a378-cgu.0.rcgu.o): In function `std::sys::windows::c::NtWriteFile':
/rustc/d5c2e9c342b358556da91d61ed4133f6f50fc0c3/library\std\src\sys\windows/c.rs:306: undefined reference to `NtWriteFile'
C:\\Users\\circleci\\AppData\\Local\\go-build\\pkgconfig\\windows_amd64\\lib/libflux-b2b5313bb4ee0b21150a1a32758418bfca79b1628ee6628f6ba0e7e3e5ce1a4f.a(std-04636370035c201d.std.3b98da929d84a378-cgu.0.rcgu.o): In function `std::sys::windows::handle::Handle::synchronous_write':
/rustc/d5c2e9c342b358556da91d61ed4133f6f50fc0c3/library\std\src\sys\windows/handle.rs:319: undefined reference to `RtlNtStatusToDosError'
collect2.exe: error: ld returned 1 exit status
```

The list of libs required to be able to build flux for windows was obtained by

* Cloning the [flux repo](https://github.com/influxdata/flux)
* `cd flux/libflux/flux`
* Running `cargo rustc -- --print native-static-libs --crate-type staticlib`

Note: there is some duplication, the command above notes that this is necessary on some platforms:

> Link against the following native artifacts when linking against this static library. The order and any duplication can be significant on some platforms.

So, I've left the duplication in place.

The result of this change was tested by forking `pkg-config` and then pointing to the fork in this PR - https://github.com/influxdata/flux/pull/5512 
